### PR TITLE
Create tests for invalidade() using multiple args

### DIFF
--- a/tests/test_cache_invalidate.py
+++ b/tests/test_cache_invalidate.py
@@ -39,3 +39,48 @@ async def test_cache_invalidate(check_lru, loop):
 
     assert ret == inputs
     check_lru(coro, hits=0, misses=6, cache=3, tasks=0)
+
+
+async def test_cache_invalidate_multiple_args(check_lru, loop):
+    @alru_cache(loop=loop)
+    async def coro(*args):
+        return len(args)
+
+    for i, size in enumerate(range(10)):
+        args = tuple(range(size))
+        ret = await coro(*args)
+        assert ret == size
+        check_lru(coro, hits=0, misses=i+1, cache=1, tasks=0)
+        coro.invalidate(*args)
+        check_lru(coro, hits=0, misses=i+1, cache=0, tasks=0)
+
+    for size in range(10):
+        args = tuple(range(size))
+        ret = await coro(*args)
+        assert ret == size
+    check_lru(coro, hits=0, misses=20, cache=10, tasks=0)
+
+
+async def test_cache_invalidate_multiple_args_different_order(check_lru, loop):
+    @alru_cache(loop=loop)
+    async def coro(*args):
+        return len(args)
+
+    for i, size in enumerate(range(2, 10)):
+        args = tuple(range(size))
+        rev_args = tuple(reversed(args))
+        ret = await coro(*args)
+        assert ret == size
+        check_lru(coro, hits=0, misses=2*i+1, cache=i+1, tasks=0)
+        ret = await coro(*rev_args)
+        # The reversed args should be a miss
+        check_lru(coro, hits=0, misses=2*i+2, cache=i+2, tasks=0)
+        coro.invalidate(*rev_args)
+        # The reversed args should be invalidated
+        check_lru(coro, hits=0, misses=2*i+2, cache=i+1, tasks=0)
+
+    for i, size in enumerate(range(2, 10)):
+        args = tuple(range(size))
+        ret = await coro(*args)
+        assert ret == size
+        check_lru(coro, hits=i+1, misses=16, cache=8, tasks=0)


### PR DESCRIPTION
Create tests for the invalidate() method varying the number of arguments
to verify if the cache will behave as expected.